### PR TITLE
fix: adjust background-color on task description and other inputs

### DIFF
--- a/asana-darkness.css
+++ b/asana-darkness.css
@@ -7636,6 +7636,10 @@ textarea {
   border-color: #42424275;
 }
 
+.TextEditor2 {
+  background-color: #303030;
+}
+
 .TextEditor2.TextEditor2--focused,
 .TextEditor2.TextEditor2--dynamic.TextEditor2--focused {
   border-color: #42424275;
@@ -8060,4 +8064,8 @@ div[class*="BaseChart-legendIcon--square"] {
 
 .AdminConsolePageStructure-header {
   background: #212121
+}
+
+.DynamicTextInput {
+  background-color: #212121;
 }


### PR DESCRIPTION
Before:
![Screenshot 2021-04-06 at 14 29 40](https://user-images.githubusercontent.com/1215056/113711054-c662b680-96e4-11eb-8033-a6e6ab61e334.png)

After:
![Screenshot 2021-04-06 at 14 31 54](https://user-images.githubusercontent.com/1215056/113711171-e8f4cf80-96e4-11eb-9709-84ecb6b835a2.png)

I noticed some fields went all white in the task detail view. 

I wasn't sure if there was any specific order to the css selectors in the file or not so I've tried to add them to where I thought was relevant - feel free to amend.