### PR TITLE
fix: adjust text color of aggregation number cell

### DIFF
--- a/asana-darkness.css
+++ b/asana-darkness.css
@@ -8121,3 +8121,7 @@ div[class*="BaseChart-legendIcon--square"] {
 .QuickAddTaskToolbar-tokenizerContainer {
   background: #303030;
 }
+
+.ProjectSpreadsheetAggregationCell-value {
+  color: #e2e2e2;
+}

--- a/asana-darkness.css
+++ b/asana-darkness.css
@@ -8122,6 +8122,11 @@ div[class*="BaseChart-legendIcon--square"] {
   background: #303030;
 }
 
+.ProjectSpreadsheetAggregationCell:hover {
+  background-color: transparent;
+  border-color: transparent;
+}
+
 .ProjectSpreadsheetAggregationCell-value {
   color: #e2e2e2;
 }


### PR DESCRIPTION
Adjusted a couple of issues with aggregation cells (text and hover styles)

Before:
![Screenshot 2021-04-20 at 17 36 59](https://user-images.githubusercontent.com/1215056/115427968-381d2300-a202-11eb-97cd-a1831ed4579a.png)

After:
![Screenshot 2021-04-20 at 17 48 47](https://user-images.githubusercontent.com/1215056/115427997-3e130400-a202-11eb-8cdf-0780cdd4f766.png)

Before:
![Screenshot 2021-04-20 at 17 51 50](https://user-images.githubusercontent.com/1215056/115428018-4408e500-a202-11eb-8eb5-b7b59cebcc91.png)

After:
![Screenshot 2021-04-20 at 17 55 24](https://user-images.githubusercontent.com/1215056/115428048-49fec600-a202-11eb-9569-81389ce843e7.png)
